### PR TITLE
Allows indenting on paper

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -309,6 +309,7 @@
 	t = replacetext(t, "\[/h2\]", "</H2>")
 	t = replacetext(t, "\[h3\]", "<H3>")
 	t = replacetext(t, "\[/h3\]", "</H3>")
+	t = replacetext(t, "\[tab\]", "&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;")
 
 	if(!iscrayon)
 		t = replacetext(t, "\[*\]", "<li>")


### PR DESCRIPTION
Pretty simple. Typing [tab] will insert a bunch of space characters that won't automatically be collapsed by html or sanitation. Useful for properly indenting paragraphs, where it used to be impossible.
Authored by CameronWoof, ported manually