### PR TITLE
Constant Chip has sprite

### DIFF
--- a/code/modules/integrated_electronics/subtypes/memory.dm
+++ b/code/modules/integrated_electronics/subtypes/memory.dm
@@ -75,7 +75,6 @@
 /obj/item/integrated_circuit/memory/constant
 	name = "constant chip"
 	desc = "This tiny chip can store one piece of data, which cannot be overwritten without disassembly."
-	icon_state = "memory"
 	complexity = 1
 	inputs = list()
 	outputs = list("output pin" = IC_PINTYPE_ANY)


### PR DESCRIPTION
I think this makes the chip use its own sprite, whereas it was using another.
originally authored by Polaris user "Anewbe", ported manually
ports PolarisSS13/Polaris/pull/5445