### PR TITLE
Fireaxe cabinets find their fireaxes in initialize(), rather than new()

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fireaxe.dm
@@ -16,7 +16,7 @@
 
 	starts_with = list(/obj/item/weapon/material/twohanded/fireaxe)
 	
-/obj/structure/closet/fireaxecabinet/New()
+/obj/structure/closet/fireaxecabinet/initialize()
 	..()
 	fireaxe = locate() in contents
 


### PR DESCRIPTION
No text was provided, but it seems to make fireaxes fetch properly
originally authored by Polaris user "Anewbe", ported manually
ports PolarisSS13/Polaris/pull/5446/files