### PR TITLE
Fixed mining cloak not being in loadouts

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout_suit.dm
+++ b/code/modules/client/preference_setup/loadout/loadout_suit.dm
@@ -247,7 +247,7 @@ datum/gear/suit/duster
 	allowed_roles = list("Cargo Technician","Quartermaster")
 
 /datum/gear/suit/roles/poncho/cloak/mining
-	display_name = "cloak, cargo"
+	display_name = "cloak, mining"
 	path = /obj/item/clothing/accessory/poncho/roles/cloak/mining
 	allowed_roles = list("Quartermaster","Shaft Miner")
 


### PR DESCRIPTION
Mining cloak was coded as Cargo Cloak
originally authored by Polaris user "Heroman3003", ported manually
ports PolarisSS13/Polaris/pull/5450