### PR TITLE
Adds various forms of colourblindness

### DIFF
--- a/code/modules/client/preference_setup/traits/trait_defines.dm
+++ b/code/modules/client/preference_setup/traits/trait_defines.dm
@@ -92,6 +92,30 @@
 	modifier_type = /datum/modifier/trait/larger
 	mutually_exclusive = list(/datum/trait/modifier/physical/smaller, /datum/trait/modifier/physical/small, /datum/trait/modifier/physical/large)
 
+/datum/trait/modifier/physical/colorblind_protanopia
+ 	name = "Protanopia"
+ 	desc = "You have a form of red-green colorblindness. You cannot see reds, and have trouble distinguishing them from yellows and greens."
+ 	modifier_type = /datum/modifier/trait/colorblind_protanopia
+ 	mutually_exclusive = list(/datum/trait/modifier/physical/colorblind_deuteranopia, /datum/trait/modifier/physical/colorblind_tritanopia, /datum/trait/modifier/physical/colorblind_monochrome)
+
+ /datum/trait/modifier/physical/colorblind_deuteranopia
+ 	name = "Deuteranopia"
+ 	desc = "You have a form of red-green colorblindness. You cannot see greens, and have trouble distinguishing them from yellows and reds."
+ 	modifier_type = /datum/modifier/trait/colorblind_deuteranopia
+ 	mutually_exclusive = list(/datum/trait/modifier/physical/colorblind_protanopia, /datum/trait/modifier/physical/colorblind_tritanopia, /datum/trait/modifier/physical/colorblind_monochrome)
+
+ /datum/trait/modifier/physical/colorblind_tritanopia
+ 	name = "Tritanopia"
+ 	desc = "You have a form of blue-yellow colorblindness. You have trouble distinguishing between blues, greens, and yellows, and see blues and violets as dim."
+ 	modifier_type = /datum/modifier/trait/colorblind_tritanopia
+ 	mutually_exclusive = list(/datum/trait/modifier/physical/colorblind_protanopia, /datum/trait/modifier/physical/colorblind_deuteranopia, /datum/trait/modifier/physical/colorblind_monochrome)
+
+ /datum/trait/modifier/physical/colorblind_monochrome
+ 	name = "Monochromacy"
+ 	desc = "You are fully colorblind. Your condition is rare, but you can see no colors at all."
+ 	modifier_type = /datum/modifier/trait/colorblind_monochrome
+ 	mutually_exclusive = list(/datum/trait/modifier/physical/colorblind_protanopia, /datum/trait/modifier/physical/colorblind_deuteranopia, /datum/trait/modifier/physical/colorblind_tritanopia)
+
 // These two traits might be borderline, feel free to remove if they get abused.
 /datum/trait/modifier/physical/high_metabolism
 	name = "High Metabolism"

--- a/code/modules/mob/_modifiers/traits.dm
+++ b/code/modules/mob/_modifiers/traits.dm
@@ -84,20 +84,38 @@
 
 	icon_scale_percent = 0.9
 
-/datum/modifier/trait/colorblind_taj
-	name = "Colorblind - B+R"
-	desc = "You are colorblind. You have a minor issue with blue colors and have difficulty recognizing them from red colors."
+/datum/modifier/trait/colorblind_protanopia
+ 	name = "Protanopia"
+ 	desc = "You have a form of red-green colorblindness. You cannot see reds, and have trouble distinguishing them from yellows and greens."
+
+ 	client_color = MATRIX_Protanopia
+
+ /datum/modifier/trait/colorblind_deuteranopia
+ 	name = "Deuteranopia"
+ 	desc = "You have a form of red-green colorblindness. You cannot see greens, and have trouble distinguishing them from yellows and reds."
+
+ 	client_color = MATRIX_Deuteranopia
+
+ /datum/modifier/trait/colorblind_tritanopia
+ 	name = "Tritanopia"
+ 	desc = "You have a form of blue-yellow colorblindness. You have trouble distinguishing between blues, greens, and yellows, and see blues and violets as dim."
+
+ 	client_color = MATRIX_Tritanopia
 	
+/datum/modifier/trait/colorblind_taj
+	name = "Colorblind - Blue-red"
+	desc = "You are colorblind. You have a minor issue with blue colors and have difficulty recognizing them from red colors."
+
 	client_color = MATRIX_Taj_Colorblind
 
 /datum/modifier/trait/colorblind_vulp
-	name = "Colorblind - G+R"
+	name = "Colorblind - Red-green"
 	desc = "You are colorblind. You have a severe issue with green colors and have difficulty recognizing them from red colors."
-	
+
 	client_color = MATRIX_Vulp_Colorblind
 
-/datum/modifier/trait/colorblind_mono
-	name = "Colorblind - Mono"
-	desc = "You are colorblind. Your condition is rare, but you can see no colors at all."
-	
+/datum/modifier/trait/colorblind_monochrome
+ 	name = "Monochromacy"
+ 	desc = "You are fully colorblind. Your condition is rare, but you can see no colors at all."
+
 	client_color = MATRIX_Monochromia


### PR DESCRIPTION
Adds four types of colorblindness to the traits in the setup menu - protanopia, deuteranopia, tritanopia, and monochromacy. Previously, there were ones defined in the code, but not actually usable to players.
originally authored by Polaris user "PrismaticGynoid", ported manually
ports PolarisSS13/Polaris/pull/5457