### PR TITLE
Let beams be shown in the Type var selection in View Variables. 

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -10,7 +10,7 @@
 	var/frequency = 1
 	hitscan = 1
 	embed_chance = 0
-	invisibility = 101	//beam projectiles are invisible as they are rendered by the effect engine
+	invisibility = 99	//beam projectiles are invisible as they are rendered by the effect engine
 	light_range = 2
 	light_power = 0.5
 	light_color = "#FF0D00"


### PR DESCRIPTION
apparently beams didn't appear in the variables list
originally authored by Polaris user "Mechoid", ported manually
ports PolarisSS13/Polaris/pull/5458