### PR TITLE
Fixes Ultra AC2's burst fire

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -38,11 +38,13 @@
 		projectiles--
 		var/P = new projectile(curloc)
 		Fire(P, target)
+		if(i == 1)
+ 			set_ready_state(0)
 		if(fire_cooldown)
 			sleep(fire_cooldown)
 	if(auto_rearm)
 		projectiles = projectiles_per_shot
-	set_ready_state(0)
+//	set_ready_state(0)
 	do_after_cooldown()
 	return
 


### PR DESCRIPTION
Mech weapons apply cooldown after firing the first projectile, to stop from spamclicking to extend a burst.
Originally authored by Polaris user "Mechoid", ported manually
Ports PolarisSS13/Polaris/pull/5485